### PR TITLE
fix broken discord invite link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -11,9 +11,10 @@ Pulsar aims to not only reach feature parity with the original Atom, but to brin
 With many new features on the roadmap, once Pulsar is stable, it will be a true, Community-Based, Hackable, Text Editor.
 
 If you would like to be more up to date on the progress within Pulsar feel free to review or contribute to:
+
 * [Pulsar Roadmap Project](https://github.com/orgs/pulsar-edit/projects/3)
 * [Editor Modernization Project](https://github.com/orgs/pulsar-edit/projects/1)
 * [Backend Roadmap Project](https://github.com/orgs/pulsar-edit/projects/2)
 * [Tentative Roadmap Discussion](https://github.com/orgs/pulsar-edit/discussions/2)
 
-Otherwise you may always check out our [Discord Server](https://discord.gg/QFxZjW4ZuS).
+Otherwise you may always check out our [Discord Server](https://discord.gg/gp9UStzsHk).


### PR DESCRIPTION
Invite was broken, so I created a new link that won't expire to replace it