### PR TITLE
Pulsar specific docs archive/migration

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,4 +1,4 @@
-**This document has moved to the [pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io) repository, as we are moving Pulsar-specific docs to the website.** The most recent copy here is still available for archival purposes. Please direct all contributions to that repository in the near future.
+**This document has moved to the [pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io) repository, as we are moving Pulsar-specific docs to the website.** The most recent copy here is still available for archival purposes. For readers, to get the most up-to-date info, please go to the aforementioned repository. For editors (contributors), please direct all contributions to the aforementioned repository in the near future.
 
 ---
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,3 +1,7 @@
+**This document has moved to the [pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io) repository, as we are moving Pulsar-specific docs to the website.** The most recent copy here is still available for archival purposes. Please direct all contributions to that repository in the near future.
+
+---
+
 # Is Pulsar-Edit the same as Atom-Community?
 
 While the original team that was working on Atom-Community is now the team creating Pulsar, they are not the same.

--- a/REPOS.md
+++ b/REPOS.md
@@ -1,4 +1,4 @@
-**This document has moved to the [pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io) repository, as we are moving Pulsar-specific docs to the website.** The most recent copy here is still available for archival purposes. Please direct all contributions to that repository in the near future.
+**This document has moved to the [pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io) repository, as we are moving Pulsar-specific docs to the website.** The most recent copy here is still available for archival purposes. For readers, to get the most up-to-date info, please go to the aforementioned repository. For editors (contributors), please direct all contributions to the aforementioned repository in the near future.
 
 ---
 

--- a/REPOS.md
+++ b/REPOS.md
@@ -1,3 +1,7 @@
+**This document has moved to the [pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io) repository, as we are moving Pulsar-specific docs to the website.** The most recent copy here is still available for archival purposes. Please direct all contributions to that repository in the near future.
+
+---
+
 # Repos
 
 With a codebase this large, it may be helpful for newcomers, and devs to an unfamiliar section of the codebase, to have a collection of what repo does what. And where is it.

--- a/project-birth/CONTRIBUTING-DURING-START.md
+++ b/project-birth/CONTRIBUTING-DURING-START.md
@@ -1,4 +1,4 @@
-**This document has moved to the [pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io) repository, as we are moving Pulsar-specific docs to the website.** The most recent copy here is still available for archival purposes. Please direct all contributions to that repository in the near future.
+**This document has moved to the [pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io) repository, as we are moving Pulsar-specific docs to the website.** The most recent copy here is still available for archival purposes. For readers, to get the most up-to-date info, please go to the aforementioned repository. For editors (contributors), please direct all contributions to the aforementioned repository in the near future.
 
 ---
 

--- a/project-birth/CONTRIBUTING-DURING-START.md
+++ b/project-birth/CONTRIBUTING-DURING-START.md
@@ -1,3 +1,7 @@
+**This document has moved to the [pulsar-edit.github.io](https://github.com/pulsar-edit/pulsar-edit.github.io) repository, as we are moving Pulsar-specific docs to the website.** The most recent copy here is still available for archival purposes. Please direct all contributions to that repository in the near future.
+
+---
+
 During these very early stages of the Pulsar project there are many things that need to be completed, and many ways that new contributors can assist.
 
 This document describes some of the specific methods and techniques that can be used to help during the transition from the soon to be sunset `Atom` to `Pulsar`. While any contributions to the `Pulsar-Edit` Organization should follow the organization wide [Contributor Guidelines](https://github.com/pulsar-edit/.github/blob/main/CONTRIBUTING.md) this document highlights some specific tasks that need extra attention at this time and how to help with them.


### PR DESCRIPTION
> *Note: This is a draft so that this could not be merged until the actual migration happens.*

This PR does Pulsar-specific docs archiving/migration for Pulsar-specific documents. I have copied the same note from the CONTRIBUTING-DURING-START doc to make it easier for the FAQ and REPOS docs.