### PR TITLE
Update labels on templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: 🐛 New Bug Report
 description: Help Pulsar improve by filing a bug report
-labels: ["bug", "triage", "question", "modernization"]
+labels: ["bug", "triage"]
 body:
 - type: checkboxes
   id: initiative-check

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: 💡 New Feature Request
 description: Got an idea for us?
-labels: ["enhancement", "documentation"]
+labels: ["enhancement"]
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
Removed "documentation" label from the FR template and remove "question & modernization" labels from the bug report template.
Triage label left on bug report for maintainers to add labels as necessary.