### PR TITLE
New Template - Fixed Template Config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-website.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-website.yml
@@ -13,6 +13,13 @@ body:
         - label: Have you made sure you issue doesn't already exist?
           required: true
   - type: textarea
+    id: where
+    attributes:
+      label: Where is the URL that this occurs?
+      placeholder: https://example.pulsar-edit.dev/example
+    validations:
+      required: true
+  - type: textarea
     id: what-happened
     attributes:
       label: What's your issue?

--- a/.github/ISSUE_TEMPLATE/bug-report-website.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-website.yml
@@ -1,0 +1,33 @@
+name: Bug Report - Website Issues
+description: Help improve our websites by filing a bug report!
+labels: ["bug"]
+body:
+  - type: checkboxes
+    id: initiative-check
+    attributes:
+      label: Thanks in advance for your bug report!
+      description: "Please make sure you have done the following:"
+      options:
+        - label: Have you reproduced this issue in incognito/private browsing?
+          required: true
+        - label: Have you made sure you issue doesn't already exist?
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What's your issue?
+      placeholder: Tell use what happened!
+    validations:
+      required: true
+  - type: textarea
+    id: os-info
+    attributes:
+      label: Which OS/Browser/Version does this happen on?
+      placeholder: Windows 10/Chrome/107.0.5304.88-Stable
+  - type: textarea
+    id: additional-context
+    attributes:
+      description: "What steps are needed to produce this issue? Any other details to add?"
+      label: "Steps to Reproduce/Additional Details:"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
 - name: Organization wide discussions
-  link: https://github.com/orgs/pulsar-edit/discussions
+  url: https://github.com/orgs/pulsar-edit/discussions
   about: For any discussion within our community
 - name: Discord
   url: https://discord.gg/7aEbB9dGRT


### PR DESCRIPTION
Since the template we are using Org Wide, is focused solely on the Pulsar Editor, it has some disadvantages when used elsewhere, mainly for web.

This introduces `Bug Report - Website Issues` which can be used on repos like [`pulsar-edit/package-frontend`](https://github.com/pulsar-edit/package-frontend) or [`pulsar-edit/pulsar-edit.github.io`](https://github.com/pulsar-edit/pulsar-edit.github.io), better allowing us to understand issues for those repos and how it affects our users.

Very likely we should look into adding more templates focused on packages, and maybe even a generic, or allow blank issues. But those can come as they are needed.

Lastly I did also fix our `ISSUE_TEMPLATE/config.yml`, it used `link:` as a key, when only `url:` is accepted.