### PR TITLE
Add discussions link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -23,5 +23,6 @@ For where to contribute or where our progess is right now there are these as sta
 
 
 For other support feel free to join us here:
+- [GitHub Discussions](https://github.com/orgs/pulsar-edit/discussions)
 - [Discord Server](https://discord.gg/7aEbB9dGRT)
 - [Reddit](https://www.reddit.com/r/pulsaredit/)


### PR DESCRIPTION
Add a link to the GH discussions page in case the tab is missed (makes it more obvious we are using it too).