### PR TITLE
Refactor `FUNDING.yml`

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-open_collective: pulsar-edit
-custom: "https://crowdin.com/project/pulsar-edit"
-github: [pulsar-edit]

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,3 +1,2 @@
 open_collective: pulsar-edit
-custom: "https://crowdin.com/project/pulsar-edit"
 github: [pulsar-edit]


### PR DESCRIPTION
Recently a `FUNDING.yml` file has been added the repo without a PR.

So this aims to do few things. Track the actions of adding a `FUNDING.yml` as well as modify it's contents.

According to GitHub docs, we only need to place the file within the root of the repo, or in `.github` or `docs` folders. So this removes a duplicate instance of the file within `.github` since we only need one.

Additionally this PR removes the custom URL to `crowdin` the reason being, at least to me personally it seems misplaced under sponsor links, as it isn't a sponsoring service. But some others disagree, so we can see where we stand on that one by allowing others to discuss. 

My other concern on `crowdin` is currently it is only being setup for the `pulsar-edit/pulsar` repo, so may not be applicable to show Organization wide.

But please feel free to review.