### PR TITLE
fix wrong text shown in the issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -20,8 +20,8 @@ body:
 - type: textarea
   id: motivation
   attributes:
-    description: "What benefits does this feature provide?"
-    label: "Enter your response below:"
+    label: "What benefits does this feature provide?"
+    description: "Enter your response below:"
     placeholder: What problem does this feature solve or what additional benefits/value does it add?
   validations:
     required: true


### PR DESCRIPTION
Instead of showing `Enter your response below:` in the issue it should show `What benefits does this feature provide?` instead.