### PR TITLE
Add version field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,7 +14,7 @@ body:
         required: true
       - label: "Have you checked our [FAQs](https://pulsar-edit.dev/docs/launch-manual/sections/faq/) to make sure your question isn't answered there?"
         required: true
-      - label: Does your issue already [exist](https://github.com/issues?q=is%3Aissue+user%3Apulsar-edit+is%3Aopen)? 
+      - label: Have you checked to make sure your issue does not already [exist](https://github.com/issues?q=is%3Aissue+user%3Apulsar-edit+is%3Aopen)? 
         required: true
       - label: Have you checked you are on the latest release of Pulsar?
         required: true
@@ -25,6 +25,12 @@ body:
     placeholder: Tell us what happened!
   validations:
     required: true
+- type: input
+  id: pulsar-version
+  attributes:
+    label: Pulsar version
+   validations:
+     required: true
 - type: dropdown
   id: os-info
   attributes:


### PR DESCRIPTION
People don't appear to be putting the versions of Pulsar into issues logs so this would add a mandatory version field (cue people typing "latest").