### PR TITLE
Add GOVERNANCE.md document

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,114 @@
+# Governance
+
+This document is designed to document and clarify the governance of the Pulsar (Pulsar-Edit) organization and teams in an open and transparent way.
+The intent is not for this to be a rigid set of rules but this does allow us to have some written reference as to how things are handled when it comes to the team organization and roles.
+
+Members may belong to more than one team or role and some come hand-in-hand with each other.
+
+We do not work on a strict set of responsibilities with a strict governance model, we mostly resemble the [Do-ocracy](https://communitywiki.org/wiki/DoOcracy) approach to governance without too much in the way of formal or elaborate governance and policies but we do of course have to have some guidelines and agreed conventions to have a working organization.
+
+## Organizational Structure
+
+This section defines the teams and roles of the Pulsar team itself.
+
+### GitHub
+
+Our primary (and currently only) official repository organization is the [Pulsar-Edit Organization](https://github.com/pulsar-edit) on GitHub.
+To run this effectively we have a number of sub-teams to perform various duties across our various repositories and other areas contained on the site.
+
+#### Admin team (Owners)
+
+Responsible for GitHub organization-wide duties such as:
+- Team and role administration
+- Repository configuration & administration
+
+#### Sub-Teams (Members)
+
+Responsible for the day to day management of repositories they are assigned to.
+- Reviewing and merging PRs
+- Triaging issues
+- Maintaining project boards
+
+Team members may be assigned to more than one team.
+
+The current teams on GitHub are as follows:
+- **Core** - works on the Main part of our editor
+- **Backend** - API and server Development
+- **Documentation** - Website and Documentation team
+- **Packages** - Works on our core packages
+
+### Discord
+
+Our Discord server is the preferred communication method for team conversations and decision-making.
+We define a number of official roles on here (as well as community ones) to make sure that administration and moderation requirements are met.
+
+#### Admins
+
+Responsible for overall configuration and maintenance of the server.
+- Creating, editing, removing channels
+- Administrating roles and members
+- Maintaining bot and app integrations
+- Kicking/Banning users that break our rules and guidelines and code of conduct.
+
+#### Moderators
+
+Responsible for the day to day moderation of the server and community interactions.
+- Ensuring civil discourse is taking place and taking action (warning users etc.)
+- De-escalating any situations or heated conversations
+
+#### Community roles
+
+Community roles can be self-granted via the `#role-select` channel.
+These members are people who are interested or participate within the Pulsar community and are expected to adhere to our code of conduct but otherwise do not have any official or specific responsibilities.
+These roles are designed to help people get updates and communicate within the specific areas of the project that they are interested in.
+Pulsar team members will also be part of these groups but they may not entirely correlate to the memberships and responsibilities granted in the GitHub sub-teams.
+These roles are:
+
+##### Core teams
+- Core - works on the Main part of our editor
+- Backend - API and server Development
+- Documentation - Website and Documentation team
+- Packages - Works on our core packages
+- Developer - Just fills in anywhere that they want
+
+##### Operating Systems
+- Linux
+- MacOS
+- Windows
+
+##### Other roles
+- Community Packages - join if you're into making packages for us
+- Updates - Join this if you're interested in receiving updates as they come out
+
+## Team member & role additions/removals
+
+Team/role administration and membership decision making is mostly covered by our [Policies](https://github.com/pulsar-edit/.github/blob/main/POLICY.md) but this section details the criteria and justifications for adding or removing team members and/or roles.
+
+### Adding members/roles
+
+Adding team members is performed in much the same way as any other decision (see [Policies](https://github.com/pulsar-edit/.github/blob/main/POLICY.md)) by proposals being made to add somebody to a team or role and a vote then taking place on that proposal.
+If the vote passes without any significant disagreements then the member can be added to the relevant team or role.
+There is no strict set of criteria for addition but generally people who are active in the community and project for an extended period of time, have contributed and added value, and share in the organization's goals & vision can be considered.
+
+### Removing members/roles
+
+This is not an action that the organization wants to perform in an ideal circumstances but this is something we do require some reference for so that people do not feel unfairly treated.
+There are a number of circumstances where this might need to be performed and this section outlines (non-exhaustively) those reasons and justifications.
+
+- **Removal requests**: If a member simply asks to be removed from a team or role for any reason then this should be done as they wish with no votes required.
+
+- **Inactivity**: If a member of a team or role becomes inactive for an extended period of time without any justification or conversation then removal may be required. The member should be first contacted by a another team member and, depending on the outcome, it should then be brought up and voted on as with any other decision. If the vote passes then the member will be removed from these various roles and teams. This vote may be to remove a person entirely or it may be to move to a role with fewer privileges but remain within the organization.
+
+-  **Misuse of privileges, negligence of duties or policy/code of conduct breaking**: If a member of a team or role is found to be misusing privileges granted to them or is found to have broken our policies, guidelines, rules or code of conduct then this may be grounds for removal of privileges or team/role membership. In serious cases it might be that we need to remove these privileges instantly in the case where it is believed that harm may come to the organization or project but these can be re-instated after discussion and voting if that is the outcome.
+
+## Modifying the organizational structure
+
+Sometimes it may be necessary to modify the organizational structure as defined in this document.
+This would be done in the same way as any other change as per our [Policies](https://github.com/pulsar-edit/.github/blob/main/POLICY.md) with proposals and a vote.
+If the vote passes then any new team or role additions can be performed in the same way as this document describes.
+
+## Other roles and responsibilities
+
+Not every single role or responsibility has been detailed in this document. Some responsibilities are handled as and when required and to the person or people most suited for it.
+Such areas include access details and administration of various tools and services used by the organization, social media account access, fund/donation access and expenses approval and organization secrets access.
+The above policies regarding adding or removing people to these specific privileges still apply.


### PR DESCRIPTION
The idea of this document is to somewhat clarify the organizational structure behind the org and have some place to reference in case it is needed or asked. For such a new project we have a lot of active contributors and by virtue of the project itself we inherited a bunch of stuff to deal with right off the bat rather than being able to grow it organically which does make keeping on top of things a little more difficult.

My main goal with this is not to add anything we aren't already doing (with one exception) nor is it to try to take the fun out of the project with strict rules and bureaucracy. It is designed so that we can have somewhere to actually come up with plans for when we have to deal with difficult situations that nobody otherwise wants to bring up.

For example the one section I added which we don't have precedence for is "removal of roles/members" which is something that has come up in discussion before for those who are still part of the GitHub org but aren't currently participating in the project.
I think this section needs more fleshing out with something we would have to decide on - for example what duration of inactivity or low contribution before we consider somebody "inactive"?
The idea here isn't to punish, it is to make administration easier and grant privileges and access only as required to prevent any damage (malicious or unintentional) to the org and team.

Much of this was based on the questions and guidance in https://opensource.com/article/20/5/open-source-governance. 

Very happy to take comments on this as I understand it could well be controversial and may need rewording in more than a few places or we may decide to forgo it entirely and place an abridged version in POLICY.md (or nothing at all).