### PR TITLE
Create rules-info-channel.md

### DIFF
--- a/social-media/discord/rules-info-channel.md
+++ b/social-media/discord/rules-info-channel.md
@@ -1,0 +1,45 @@
+# Rules
+
+- Be Kind - This isn't a place for aggression, this is a place to work together to create awesome code.
+- Be Respectful - We aim to have a community of accepting individuals. Being respectful includes not making racist, homophobic, or sexist insults. No matter someone's race, gender, sexuality, political affiliation, or experience we all are here together and should be treated with respect.
+- No Private Messages - Unless confirmed publicly on the server you should never send private unsolicited messages to any members of this server. The only exception would be to report a sensitive issue to the @Admins  or @Moderators. But even then it is recommended to publicly confirm that they are okay with you sending a private message.
+- No Advertising - Please no advertisements of products or services independent of organic conversation.
+- Match your display name to what is on github. This helps for us assigning you to a team on there and allows us to contact you better for updates and concerns on contributions. This is ***NOT*** a strict requirement but it is extremely helpful in operations here.
+
+
+# Conduct
+
+https://github.com/pulsar-edit/pulsar/blob/master/CODE_OF_CONDUCT.md
+
+
+# Contributing
+
+If you are a new contributor to Pulsar and want to know how to help, feel free to interact on the server or GitHub. But if you'd like to just start programming please read our new contributor help guide. https://github.com/pulsar-edit/.github/blob/main/project-birth/CONTRIBUTING-DURING-START.md 
+
+
+# Roles
+
+Once you're done here please make your way over to ⁠role-select  and grab some roles. It helps us know who is interested and helping and who we can ping for various things that come up here as we form teams. Especially if we're not prompt enough to add you to the proper team on github. The description of these are below:
+
+These are the roles for the server in case you want to join them:
+Organizational:
+- Documentation - for our documentation. This relates to our site and all the documents we handle between it and the pulsar-edit/.github repo
+- Backend - API and server related development
+- Developer - if you're not sure what you want to contribute too or just want to contribute wherever.
+- Core - Works on the core editor and all the things that make it tick.
+- Packages - our core packages
+
+Community Related:
+- Team - these people have contributed a significant amount and have generally been a help in the community
+- Admin/Mod - these people are admins and mods bc of their help and demonstratable necessity for their place as someone to help with moderation and various other things within the community
+- Updates - when we post updates you'll get a notification. Consider this ⁠pulsar-announcements and eventually ⁠community-updates
+- Community - if you develop a package on your own outside the org and submit it grab this one! We'll try to post updates about development on this soon as this is a upcoming feature in the v2 backend!
+
+OS(for support and supporting others):
+- Windows
+- Linux
+- MacOS
+
+# Invite
+
+Invite link to the server(due to change when we are able to get a vanity link) https://discord.gg/7aEbB9dGRT


### PR DESCRIPTION
This is a update to the rules(and potentially a renaming to rules-and-info). This better organizes that channel and gets rid of messages that should've been placed elsewhere.

This also adds the new team role(for experienced contributors that we can trust to support and answer questions of other users). I'd also like to propose this as the starting point to also discuss the colors of those roles for accessibility purposes.

Since beyond bots we've added to help add us these are the current colors and organization of those roles:

![image](https://github.com/pulsar-edit/.github/assets/16845458/8350bda4-c4a1-429a-baf8-308478d73b0c)

![image](https://github.com/pulsar-edit/.github/assets/16845458/21e2ee3b-6c22-4077-be02-b8febea4c6a1)

![image](https://github.com/pulsar-edit/.github/assets/16845458/8ccc099c-41ab-4009-a2aa-4719b53a08ad)

If we could boost ourselves to level 2 and/or get the discovery we might be able to label them differently w/images instead. But we esp need to fix colors as we now have 3 different roles that are purple and need fixing at this point as part of this.

Discussion and changes are welcome to this.