### PR TITLE
Add Lemmy to social posts checklist

### DIFF
--- a/guides/release-checklist.md
+++ b/guides/release-checklist.md
@@ -21,6 +21,7 @@ A checklist for releases. This is for the "Regular" releases. (Rolling releases 
   - Discord announcement
   - Reddit post
   - Mastodon post
+  - Lemmy post
 
 ## Steps:
 


### PR DESCRIPTION
Now Lemmy is official and open for business we should add this to the checklist.