### PR TITLE
Add Public Messaging Guide

### DIFF
--- a/guides/update-public-messaging.md
+++ b/guides/update-public-messaging.md
@@ -1,0 +1,43 @@
+# Update Public Messaging
+
+A document to consult every time any public messaging is modified for Pulsar.
+
+Due to Pulsar's large presence on the web, it became necessary to ensure changes against this messaging in a single place, results in reviews or checks in every single place. This ensures any and all changes fit our character, as well as the story they are experiencing.
+
+## Steps:
+
+When any piece of public messaging needs to be updated, here are a few key steps to ensure things go smoothly.
+
+1. Take into account our official tagline: `A Community-led Hyper-Hackable Text Editor`
+2. If necessary take into account our de-facto farewell: `... see you amongst the stars!`
+3. Avoid temporary language, as it may quickly become outdated.
+4. Ensure the Pulsar Team agrees with the language proposed.
+5. Take into consideration the language used throughout other public messaging. (Listed Below)
+6. Once done, take the time to consider if other public messaging needs to be updated. (Listed Below)
+
+## Public Messaging Locations
+
+The following list will contain links to all other public messaging locations for the Pulsar-Edit org.
+Along with a description of where to look for the text, or what it may be labeled.
+
+### Pulsar GitHub Organization
+
+- README.md: https://github.com/pulsar-edit
+
+### Crowdin
+
+- Description: https://crowdin.pulsar-edit.dev/
+
+### GitHub Sponsors
+
+- Introduction: https://github.com/sponsors/pulsar-edit
+- Short Bio: https://github.com/sponsors/pulsar-edit
+
+### Pulsar Subreddit
+
+- About: https://www.reddit.com/r/pulsaredit/
+
+### Open Collective
+
+- Tagline: https://opencollective.com/pulsar-edit
+- About: https://opencollective.com/pulsar-edit#category-ABOUT


### PR DESCRIPTION
This PR adds a guide to inform contributors how to update public messaging in the Pulsar Organization.

This PR supersedes #241, taking a different more dynamic approach to this topic.