### PR TITLE
Update release-checklist.md guide docs

### DIFF
--- a/guides/release-checklist.md
+++ b/guides/release-checklist.md
@@ -79,6 +79,10 @@ Note: after the "Changelog" steps are done, the remaining steps can be done in w
 
 ### How to rename binaries
 
+_\[NOTE: Feel free to skip this section. This section is now automated by a script in CI. This section of the guide remains as a reference "for reference's sake" -- if you want to know how it's done manually, or context for how this naming convention came about, feel free to read, otherwise know it is handled automatically in CI._
+
+_See the script: https://github.com/pulsar-edit/pulsar/blob/master/script/rename.js, and the PR that introduced it, for explanation/context: https://github.com/pulsar-edit/pulsar/pull/675. Original section continues below:\]_
+
 Here is the naming scheme we have been using, which was initially suggested by @confused-techie. Copy-pasted from here: https://discord.com/channels/992103415163396136/1064364297033093150/1064393610910511197
 
 Add prefixes to the binary names output by electron-builder in Cirrus, like so:

--- a/guides/release-checklist.md
+++ b/guides/release-checklist.md
@@ -115,6 +115,12 @@ Example on macOS:
 shasum -a 256 * | tee SHA256SUMS.txt
 ```
 
+Example on Linux (Ubuntu):
+
+```bash
+sha256sum * | tee SHA256SUMS.txt
+```
+
 ## Release Day Template
 
 On release day it may be helpful to create a new issue with the following template. Which allows contributors to communicate in a central location about executing the release, and allows easy communication about the steps of the release that are completed.


### PR DESCRIPTION
Just some slight updates I've been meaning to make to the guides/release-checklist.md but hadn't gotten around to before now.

- Add a note explaining that we have CI scripts to automatically rename binaries for you for Regular releases, no need to do it manually anymore generally speaking
- Add example command to make `SHA256SUMS.txt` on Linux (Ubuntu).
  - We already had instructions for macOS
  - Note: I tried figuring out a Powershell script for Windows, to get shasums of all the files and collect them all in one file like we can easily do on macOS or Linux, but it was taking me a while. Both because I'm not that familiar with Powershell, but also because I think it is genuinely more complicated (maybe not possible as a one-liner) in Powershell or CMD.exe (???) I dunno, but I gave up after about an hour or two of trying.