### PR TITLE
Update issue template - Apple chips

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -58,7 +58,7 @@ body:
     label: Which CPU architecture are you running this on?
     options:
       - x86_64/AMD64
-      - Apple M1/M2
+      - Apple M-series
       - ARM64/AArch64
   validations:
     required: false


### PR DESCRIPTION
We currently list the M1 and M2 specifically but now there is an M3 series out for laptops and even an M4 (only for iPad currently) I'm thinking we should just make this generic.