### PR TITLE
Fix org level issue templates for main Pulsar repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/regular-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/regular-release-checklist.md
@@ -1,0 +1,24 @@
+---
+name: Regular Release Checklist
+about: Checklist to ensure all Regular release steps are done and "deliverables" are
+  published
+title: Release Checklist for Regular Release v[version here, e.g. v1.130.0]
+labels: ''
+assignees: ''
+
+---
+
+# Regular Release v[version here, such as v1.130.0]
+
+- [ ] ChangeLog updated (`CHANGELOG.md` and `welcome` package)
+- [ ] Blurb Text Complete (Comment Below)
+- [ ] Version Bump PR Created
+- [ ] Binaries Uploaded to GitHub (Including renamed binaries, and SHASUM file)
+- [ ] Release Posted! 🎊
+- [ ] Update Chocolatey Release
+- [ ] Website Links updated
+- [ ] Blog Post
+- [ ] Discord Announcement
+- [ ] Reddit Announcement
+- [ ] Mastodon Announcement
+- [ ] Lemmy Announcement


### PR DESCRIPTION
Counterpart PR to https://github.com/pulsar-edit/pulsar/pull/1527 in our main Pulsar repo.

---

PR https://github.com/pulsar-edit/pulsar/pull/1346 adds a `.github/ISSUE_TEMPLATES/` dir to the repo along with an issue template regular-release-template.md. The problem is that the presence of this (I _believe_ at least, it's weirdly difficult to find proof in the github docs) has caused the org level issue templates to no longer apply:

For example https://github.com/pulsar-edit/ppm/issues/new/choose:
<img width="550" height="303" alt="image" src="https://github.com/user-attachments/assets/684fcc6a-9e5a-4faa-b81c-aad06340749b" />

Vs https://github.com/pulsar-edit/ppm/issues/new/choose (with no .github/issue_template dir):
<img width="560" height="463" alt="image" src="https://github.com/user-attachments/assets/c38ecc9a-c723-4b4f-8e11-096f42577570" />

This PR simply moves `regular-release-template.md` into the existing issue_template dir which should put the new issue chooser defined at the org level config.yml back in control.

It is also possible it affected the pull request template as well as that seems to have also gone awol.

We do need to do some housekeeping of these templates, some of the links are a bit all over the place, but I'm going to try to have a look at some of these soon, including maybe converting this checklist one to YAML as I think having a mix can do something odd...